### PR TITLE
chore: build and push docker image

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -3,7 +3,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 0 * * 1" # Every Monday at 12:00 AM UTC.
-  pull_request:
 
 jobs:
   backend_release:

--- a/docker-compose.advanced.yml
+++ b/docker-compose.advanced.yml
@@ -16,6 +16,7 @@ services:
       - REDIS_HOST=redis-stack
       - REDIS_PORT=6379
       - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - FLIPT_SERVER_ADDR=http://flipt:8080
     depends_on:
       - "redis-stack"
 

--- a/docker-compose.basic.yml
+++ b/docker-compose.basic.yml
@@ -8,7 +8,7 @@ services:
       - "6379:6379"
 
   backend:
-    build: ./backend
+    image: ghcr.io/flipt-io/chatbot-example/backend:latest
     container_name: backend
     ports:
       - "9000:9000"
@@ -16,6 +16,7 @@ services:
       - REDIS_HOST=redis-stack
       - REDIS_PORT=6379
       - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - FLIPT_SERVER_ADDR=http://flipt:8080
     depends_on:
       - "redis-stack"
 

--- a/docker-compose.gitops.yml
+++ b/docker-compose.gitops.yml
@@ -16,6 +16,7 @@ services:
       REDIS_HOST: redis-stack
       REDIS_PORT: 6379
       OPENAI_API_KEY: ${OPENAI_API_KEY}
+      FLIPT_SERVER_ADDR: http://flipt:8080
     depends_on:
       - "redis-stack"
 


### PR DESCRIPTION
This PR adds a GH action for building and pushing the `backend` docker image.

Completes FLI-446