### PR TITLE
chore: extend enum for adding server addresses

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -5,8 +5,10 @@ import random
 import redis
 import responses
 import time
+from aenum import extend_enum
 from flask import Flask, current_app, request, jsonify
 from flask_cors import CORS
+from flipt.environment import FliptApiEnvironment
 from flipt.client import FliptApi
 from flipt import evaluationRequest
 from langchain.text_splitter import MarkdownTextSplitter
@@ -27,15 +29,9 @@ openai_api_key = os.environ.get("OPENAI_API_KEY")
 flag_key = os.environ.get("FLIPT_FLAG_KEY") or "chat-personas"
 server_addr = os.environ.get("FLIPT_SERVER_ADDR") or "http://localhost:8080"
 
+extend_enum(FliptApiEnvironment, "FLIPT", server_addr)
 
-class FliptApiEnivronment:
-    def __init__(self, addr="http://localhost:8080"):
-        self.value = addr
-
-
-fenv = FliptApiEnivronment(addr=server_addr)
-
-flipt_api = FliptApi(environment=fenv)
+flipt_api = FliptApi(environment=FliptApiEnvironment.FLIPT)
 
 default_pre_prompt = """
 You are a chatbot that will respond to questions in a very helpful and kind manner based on some facts below about the product Flipt.

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,3 +7,4 @@ sentence_transformers==2.2.2
 gunicorn==20.1.0
 openai==0.27.8
 flipt==0.2.5
+aenum==3.1.14


### PR DESCRIPTION
There is a library that can extend `enum`s on a class that already inherits from `enum.Enum`: https://stackoverflow.com/questions/33679930/how-to-extend-python-enum

It is not trivially easy to do so otherwise.