### PR TITLE
fix(backend): skip openai when key is empty string

### DIFF
--- a/chatbot/backend/main.py
+++ b/chatbot/backend/main.py
@@ -227,7 +227,7 @@ def chat():
             pass
 
         res = responses.flipt_responses[persona][random.randint(0, 9)]
-        if openai_api_key != None:
+        if openai_api_key != None and openai_api_key != "":
             sentiment_for_prompt = persona
             if sentiment_for_prompt == "liar":
                 sentiment_for_prompt = "deceitful"


### PR DESCRIPTION
When the OpenAI key was missing I was seeing the following error on chat message POST:
```
chatbot-backend-1      | [2023-06-27 10:08:05,974] ERROR in app: Exception on /chat [POST]
chatbot-backend-1      | Traceback (most recent call last):
chatbot-backend-1      |   File "/usr/local/lib/python3.9/site-packages/flask/app.py", line 2190, in wsgi_app
chatbot-backend-1      |     response = self.full_dispatch_request()
chatbot-backend-1      |   File "/usr/local/lib/python3.9/site-packages/flask/app.py", line 1486, in full_dispatch_request
chatbot-backend-1      |     rv = self.handle_user_exception(e)
chatbot-backend-1      |   File "/usr/local/lib/python3.9/site-packages/flask_cors/extension.py", line 165, in wrapped_function
chatbot-backend-1      |     return cors_after_request(app.make_response(f(*args, **kwargs)))
chatbot-backend-1      |   File "/usr/local/lib/python3.9/site-packages/flask/app.py", line 1484, in full_dispatch_request
chatbot-backend-1      |     rv = self.dispatch_request()
chatbot-backend-1      |   File "/usr/local/lib/python3.9/site-packages/flask/app.py", line 1469, in dispatch_request
chatbot-backend-1      |     return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
chatbot-backend-1      |   File "/app/main.py", line 236, in chat
chatbot-backend-1      |     res = rs.generate_response(query, pre_prompt, sentiment_for_prompt)
chatbot-backend-1      |   File "/app/main.py", line 161, in generate_response
chatbot-backend-1      |     chain = LLMChain(llm=OpenAI(temperature=0), prompt=prompt)
chatbot-backend-1      |   File "/usr/local/lib/python3.9/site-packages/langchain/load/serializable.py", line 61, in __init__
chatbot-backend-1      |     super().__init__(**kwargs)
chatbot-backend-1      |   File "/usr/local/lib/python3.9/site-packages/pydantic/main.py", line 341, in __init__
chatbot-backend-1      |     raise validation_error
chatbot-backend-1      | pydantic.error_wrappers.ValidationError: 1 validation error for OpenAI
chatbot-backend-1      | __root__
chatbot-backend-1      |   Did not find openai_api_key, please add an environment variable `OPENAI_API_KEY` which contains it, or pass  `openai_api_key` as a named parameter. (type=value_error)
```

This change just checks that the key is both not-None and not empty.